### PR TITLE
Allow building via dockerTools.streamLayeredImage.

### DIFF
--- a/bin/layers-from-fatjar
+++ b/bin/layers-from-fatjar
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 
 function usage() {
 cat <<-EOF
-USAGE: $0 [options] <fat.jar> <output-directory>
+USAGE: $0 [options] <fat.jar> [output-directory]
 
 Split a fat-jar into reusable docker layers.
 
@@ -17,10 +17,12 @@ OPTIONS:
 -- ARGS               Indicate aguments for docker build or nix build.
 
 -B, --docker-build    Run Docker build.
-                      You might want to use -- to indicate arguments.
+                      You might want to use -- to indicate arguments for 'docker build'.
+                      eg: '-- -t my-app:latest'
 
 -N, --nix-build       Build a derivation from nix streamLayeredImage.
-                      You might want to use -- to indicate arguments.
+                      You might want to use -- to indicate arguments for 'nix build'.
+                      eg: '-- --show-trace'
                       Implies --nix.
 
 -t, --top-layer       Create a layer for top-level files inside fatjar.
@@ -40,8 +42,8 @@ OPTIONS:
 -m, --main CLASS      Use CLASS as entrypoint.
                       Defaults to Main-Class from fatjar manifest.
 
--n, --nix             Generate a layers.nix file which can be used
-                      as content for nixpkgs.dockerTools.buildLayeredImage.
+-n, --nix             Generate a flake.nix file producing a
+                      nixpkgs.dockerTools.buildLayeredImage.
 
 Homepage: https://github.com/vic/docker-layered-fatjar
 EOF
@@ -227,36 +229,19 @@ ENTRYPOINT [ "java", "$MAIN" ]
 EOF
 fi
 
-function gen_layers_nix() {
-###
-# Create a layers.nix file containing a derivation for each directory.
-###
-cat <<-EOF > "$WORKDIR/layers.nix"
-{ pkgs ? import <nixpkgs> {}, ...}: [
-EOF
-
-for n in $(seq 0 $LAYER); do
-cat <<-EOF >> "$WORKDIR/layers.nix"
-(pkgs.stdenvNoCC.mkDerivation {
-  name = "layer-$n";
-  version = 0;
-  phases = "install";
-  src = ./layer-$n.jar;
-  install = ''
-  mkdir -p "\$out/$CONTENT_ROOT"
-  cp -r "\$src" "\$out/$CONTENT_ROOT"
-  '';
-})
-EOF
-done
-
-cat <<-EOF >> "$WORKDIR/layers.nix"
-]
-EOF
-}
-
 if test -n "$NIXGEN"; then
-  gen_layers_nix
+  cp "${NIX_TEMPLATE}"/*.nix "$WORKDIR/"
+  if ! test -f "$WORKDIR/baseImage.nix"; then
+    echo nix-prefetch-docker "$FROMBASE" >&2
+    nix-prefetch-docker "$FROMBASE" > "$WORKDIR/baseImage.nix"
+  fi
+  cat <<-EOF > "$WORKDIR/args.nix"
+{ pkgs, ...}: {
+  nLayers = $LAYER + 1; # Exclusive.
+  contentRoot = "$CONTENT_ROOT";
+  main = "$MAIN";
+}
+EOF
 fi
 
 if test -n "$RUN_DOCKER_BUILD" && test -z "$RUN_NIX_BUILD"; then
@@ -264,7 +249,16 @@ if test -n "$RUN_DOCKER_BUILD" && test -z "$RUN_NIX_BUILD"; then
 fi
 
 if test -n "$RUN_NIX_BUILD" && test -z "$RUN_DOCKER_BUILD"; then
-  nix build -f "$WORKDIR/default.nix" --impure -I workdir="$WORKDIR" "${ARGS[@]}"
+  (cd "$WORKDIR"; git init; git add . ; nix build "$WORKDIR" "${ARGS[@]}")
+  cat <<-EOF
+To load your image locally, use:
+
+  $WORKDIR/result/bin/load-to-local-docker
+
+To push your image to a remote container registry, use: (no docker daemon needed)
+
+  $WORKDIR/result/bin/copy-to-docker-registry docker://some_docker_registry/myimage:tag
+EOF
 fi
 
 exit 0

--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1664957017,
-        "narHash": "sha256-beO1xAHLXXfVTAq4E/pbdt+vUMgYtOGjAUyPq81LV7c=",
+        "lastModified": 1665033240,
+        "narHash": "sha256-4RVvZGPvlJCWZxBST9KjeW7UwNTpEvWlaNLnHEFBcy4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1237bfb999d269c46868b34bb4b33b5ff084ac5f",
+        "rev": "5f223154a64b7a29d0094d7d6ecb5ce624c3527e",
         "type": "github"
       },
       "original": {

--- a/nix/flake-outputs.nix
+++ b/nix/flake-outputs.nix
@@ -10,7 +10,7 @@ let
       packages.default = main;
       apps.default = flake-utils.lib.mkApp { drv = main; };
       devShells.default = pkgs.mkShell {
-        packages = with pkgs; [ main mill jre_headless docker-client ];
+        packages = with pkgs; [ main mill jre_headless docker-client nix-prefetch-docker ];
       };
     });
 in global // flake-utils.lib.eachDefaultSystem per-system

--- a/nix/packages/layers-from-fatjar.nix
+++ b/nix/packages/layers-from-fatjar.nix
@@ -1,12 +1,18 @@
-{ lib, makeWrapper, coreutils, docker-client, jre_headless, stdenvNoCC, ... }:
-stdenvNoCC.mkDerivation {
+{ lib, pkgs, ... }:
+pkgs.stdenvNoCC.mkDerivation {
   name = "layers-from-fatjar";
   version = 0;
   phases = "install";
-  buildInputs = [ makeWrapper ];
-  install = ''
+  buildInputs = [ pkgs.makeWrapper ];
+  install = let
+    deps = with pkgs; [ bash gawk coreutils
+                        docker-client jre_headless
+                        nixVersions.stable nix-prefetch-docker
+                      ];
+  in ''
   mkdir -p $out/bin
   makeWrapper ${./../../bin/layers-from-fatjar} $out/bin/layers-from-fatjar \
-    --prefix PATH : ${lib.makeBinPath [ coreutils docker-client jre_headless ]}
+    --prefix PATH : ${lib.makeBinPath deps} \
+    --set NIX_TEMPLATE "${./../template}"
   '';
 }

--- a/nix/template/default.nix
+++ b/nix/template/default.nix
@@ -1,0 +1,34 @@
+{ pkgs ? import <nixpkgs> {}, ... }:
+let
+  stream = pkgs.callPackage ./streamImage.nix {};
+
+  dockerLoad = with pkgs; writeShellScript "load-locally" ''
+  ${stream} | ${docker-client}/bin/docker load "$@"
+  '';
+
+  registryPush = with pkgs; writeShellScript "push-to-registry" ''
+  if test -z "''${1:-}"; then
+  cat <<-EOF
+      USAGE: $0 <docker-url> [skopeo-copy-options]
+
+      Example: $0 docker://some_docker_registry/myimage:tag
+
+      See: https://github.com/containers/skopeo/blob/main/docs/skopeo-copy.1.md
+  EOF
+    exit 1
+  fi
+  echo skopeo copy docker-archive:/dev/stdin "$@"
+  ${stream} | ${gzip}/bin/gzip --fast | ${skopeo}/bin/skopeo copy docker-archive:/dev/stdin "$@"
+  '';
+
+in pkgs.stdenvNoCC.mkDerivation {
+  name = "fatjar";
+  version = 0;
+  phases = [ "install" ];
+  install = ''
+  mkdir -p $out/bin
+  ln -s ${dockerLoad} $out/bin/stream-docker-image
+  ln -s ${dockerLoad} $out/bin/load-to-local-docker
+  ln -s ${registryPush} $out/bin/copy-to-docker-registry
+  '';
+}

--- a/nix/template/flake.nix
+++ b/nix/template/flake.nix
@@ -1,0 +1,11 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs = {nixpkgs, flake-utils, ...}: flake-utils.lib.eachDefaultSystem (system: let
+    pkgs = import nixpkgs { inherit system; };
+    in {
+      packages.default = pkgs.callPackage ./default.nix {};
+    });
+}

--- a/nix/template/mkConfig.nix
+++ b/nix/template/mkConfig.nix
@@ -1,0 +1,31 @@
+# see: https://nixos.org/manual/nixpkgs/stable/#ssec-pkgs-dockerTools-buildLayeredImage
+{ pkgs, ... }:
+cfg:
+let
+  args = pkgs.callPackage ./args.nix {};
+  inherit (args) nLayers main contentRoot;
+  mkLayer = pkgs.callPackage ./mkLayer.nix {};
+  layers = builtins.genList (n: mkLayer { inherit n contentRoot; }) nLayers;
+  jars = builtins.genList(n: "${contentRoot}/layer-${toString n}.jar") nLayers;
+  classpath = pkgs.lib.concatStringsSep ":" jars;
+  baseImage = pkgs.dockerTools.pullImage (import ./baseImage.nix);
+in
+{
+  fromImage = baseImage;
+
+  name = cfg.name or "fatjar";
+
+  contents = layers;
+
+  enableFakechroot = false;
+
+  # Run-time configuration of the container. A full list of the options are available at in the Docker Image Specification v1.2.0.
+  # https://github.com/moby/moby/blob/master/image/spec/v1.2.md#image-json-field-descriptions
+  config = let
+    env =  {
+      Env = [ ''CLASSPATH="${classpath}"'' ];
+      Cmd = [];
+    };
+    entry = if main == "" then {} else { Entrypoint = [ "java" "-cp" classpath main ]; };
+  in env // entry;
+}

--- a/nix/template/mkLayer.nix
+++ b/nix/template/mkLayer.nix
@@ -1,0 +1,11 @@
+{ stdenvNoCC, ... }:
+{ contentRoot, n, }: stdenvNoCC.mkDerivation {
+  name = "layer-${toString n}";
+  version = 0;
+  phases = "install";
+  src = "${./.}/layer-${toString n}.jar";
+  install = ''
+  mkdir -p "$out/${contentRoot}"
+  cp -r "$src" "$out/${contentRoot}"
+  '';
+}

--- a/nix/template/streamImage.nix
+++ b/nix/template/streamImage.nix
@@ -1,0 +1,5 @@
+{ pkgs ? import <nixpkgs> {}, ... }:
+let
+  cfg = (pkgs.callPackage ./mkConfig.nix {}) {};
+in
+pkgs.dockerTools.streamLayeredImage cfg


### PR DESCRIPTION
Produces a flake with a docker-prefetched baseImage.nix and a couple of scripts to load locally and copy using skopeo.